### PR TITLE
fix: add undefined to the return type of get

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module "lru-native2" {
     constructor(options: LRUCacheOptions)
 
     public set(key: K, value: V): void
-    public get(key: K): V
+    public get(key: K): V | undefined
     public setMaxElements(n: number): void
     public setMaxAge(millis: number): void
     public remove(key: K): void


### PR DESCRIPTION
Super tiny typings fix here.
If an item is not in cache, `undefined` will be returned, so it should be part of the return types.