### PR TITLE
build with node 16

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,8 +3,8 @@
     {
       "target_name": "native",
       "sources": ["src/native.cc", "src/LRUCache.cc"],
-      "cflags": ["-std=c++11", "-O2"],
-      "cflags_cc": ["-std=c++11", "-O2"],
+      "cflags": ["-O2"],
+      "cflags_cc": ["-O2"],
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
       ]


### PR DESCRIPTION
Sorry there was one setting missing, otherwise the compile fails with:

```
  CXX(target) Release/obj.target/native/src/native.o
In file included from /root/.cache/node-gyp/16.3.0/include/node/v8.h:30,
                 from /root/.cache/node-gyp/16.3.0/include/node/node.h:63,
                 from ../node_modules/nan/nan.h:56,
                 from ../src/native.cc:1:
/root/.cache/node-gyp/16.3.0/include/node/v8-internal.h: In function 'void v8::internal::PerformCastCheck(T*)':
/root/.cache/node-gyp/16.3.0/include/node/v8-internal.h:452:38: error: 'remove_cv_t' is not a member of 'std'; did you mean 'remove_cv'?
  452 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
      |                                      ^~~~~~~~~~~
      |                                      remove_cv
/root/.cache/node-gyp/16.3.0/include/node/v8-internal.h:452:38: error: 'remove_cv_t' is not a member of 'std'; did you mean 'remove_cv'?
  452 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
      |                                      ^~~~~~~~~~~
      |                                      remove_cv
/root/.cache/node-gyp/16.3.0/include/node/v8-internal.h:452:50: error: template argument 2 is invalid
  452 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
      |                                                  ^
/root/.cache/node-gyp/16.3.0/include/node/v8-internal.h:452:63: error: '::Perform' has not been declared
  452 |             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
      |                                                               ^~~~~~~
In file included from ../node_modules/nan/nan.h:56,
                 from ../src/native.cc:1:
```